### PR TITLE
Update documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,22 +2,35 @@
 
 [GoDoc](https://godoc.org/github.com/BlueOwlOpenSource/endpoint)
 
-This package provides way to organize injectors and wrappers when creating http handlers (endpoints).
-When using the pre-register variants of creating services, it allows individual endpoints to
-self-register.
+This package attempts to solve several issues with http endpoint handlers:
 
-Services can be pre-registered and started later or they can be registered
-and stated immediately.  Services can be started with a binder that matches
-http.HandlerFunc, or they can be started with a *mux.Router.  Combined with
-the pre-register vs. start immedidately, services come in four flavors:
-ServiceRegistration, Service, ServiceRegistrationWithMux, and ServiceWithMux.
+ * Chaining actions to create composite handlers 
+ * Wrapping endpoint handlers with before/after actions
+ * Dependency injection for endpoint handlers
+ * Binding handlers to their endpoints next to the code that defines the endpoints
+ * Delaying initialization code execution until services are started allowing services that are not used to remain uninitialized
+ * Reducing the cost of refactoring endpoing handlers passing data directly from producers to consumers without needing intermediaries to care about what is being passed
+ * Avoid the overhead of verifying that requested items are present when passed indrectly (a common problem when using context.Context to pass data indirectly)
 
-Endpoint provides a clean way to wrap endpoint implementations and factor out common
-code from endpoints.  Example useses include:
+It does this by defining endpoints as a sequence of handler functions.  Handler functions
+come in different flavors.  Data is passed from one handler to the next using reflection to 
+match the output types with input types requested later in the handler chain.  To the extent
+possible, the handling is pre-computed so there is very little reflection happening when the
+endpoint is actually invoked.
+
+Endpoints are registered to services before or after the service is started.
+
+When services are pre-registered and started later, it is possible to bind endpoints
+to them in init() functions and thus colocate the endpoint binding with the endpoint
+definition and spread the endpoint definition across multiple files and/or packages.
+
+Services come in two flavors: one flavor binds endpoints with http.HandlerFunc and the
+other binds using mux.Router.  
+
+Example useses include:
 
  * Turning output structs into json
  * Common error handling
  * Common logging
  * Common initialization
  * Injection of resources and dependencies
-

--- a/README.md
+++ b/README.md
@@ -9,13 +9,13 @@ This package attempts to solve several issues with http endpoint handlers:
  * Dependency injection for endpoint handlers
  * Binding handlers to their endpoints next to the code that defines the endpoints
  * Delaying initialization code execution until services are started allowing services that are not used to remain uninitialized
- * Reducing the cost of refactoring endpoing handlers passing data directly from producers to consumers without needing intermediaries to care about what is being passed
- * Avoid the overhead of verifying that requested items are present when passed indrectly (a common problem when using context.Context to pass data indirectly)
+ * Reducing the cost of refactoring endpoint handlers passing data directly from producers to consumers without needing intermediaries to care about what is being passed
+ * Avoid the overhead of verifying that requested items are present when passed indirectly (a common problem when using context.Context to pass data indirectly)
 
 It does this by defining endpoints as a sequence of handler functions.  Handler functions
 come in different flavors.  Data is passed from one handler to the next using reflection to 
 match the output types with input types requested later in the handler chain.  To the extent
-possible, the handling is pre-computed so there is very little reflection happening when the
+possible, the handling is precomputed so there is very little reflection happening when the
 endpoint is actually invoked.
 
 Endpoints are registered to services before or after the service is started.
@@ -27,7 +27,7 @@ definition and spread the endpoint definition across multiple files and/or packa
 Services come in two flavors: one flavor binds endpoints with http.HandlerFunc and the
 other binds using mux.Router.  
 
-Example useses include:
+Example uses include:
 
  * Turning output structs into json
  * Common error handling

--- a/doc.go
+++ b/doc.go
@@ -18,7 +18,7 @@ can all be used to provide data and code to downstream handlers.  Downstream
 handlers request what they need by including appropriate types in their
 argument lists.  Injectors are invoked only if their outputs are consumed.
 
-Code juxtiposition: when using pre-registered services, endpoint binding can
+Code juxtaposition: when using pre-registered services, endpoint binding can
 be registered next to the code that implements the endpoint even if the endpoints
 are implemented in multiple files and/or packages.
 
@@ -53,7 +53,7 @@ Handler is a function that is used to help define an endpoint.
 
 Handler collection is a group of handlers.
 
-Downstream handlers are handler that are to the right of the current hanlder
+Downstream handlers are handlers that are to the right of the current handler
 in the list of handlers.  They will be invoked after the current handler.
 
 Upstream handlers are handlers that are to the left of the current handler
@@ -71,8 +71,8 @@ with without.
 
 Pre-registered services are not initialized until they are Start()ed.  This
 allows them to depend upon resources that may not may not be available without
-causing a startup panic unless they're started without their required resrouces.
-It also allows endpoints to be regisered in init() functions next to the
+causing a startup panic unless they're started without their required resources.
+It also allows endpoints to be registered in init() functions next to the
 definition of the endpoint.
 
 Handlers
@@ -85,7 +85,7 @@ handler can be used by any handler to its right and then as the
 handlers return, the data returned can be used by any handler to its
 left.  The data provided and required is identified by its type.
 Since Go makes it easy to make aliases of types, it is easy to make
-types distict.  When there is not an exact match of types, the framework
+types distinct.  When there is not an exact match of types, the framework
 will use the closest (in distance) value that can convert to the
 required type.
 

--- a/doc.go
+++ b/doc.go
@@ -5,11 +5,60 @@ Package endpoint is a general purpose web server framework that provides a
 concise way to handle errors and inject dependencies into http endpoint
 handlers.
 
-Endpoints are assembled from a collection handlers.  As much as possible,
-work is done at initialization time rather than endpoint invocation time.
+Why?
+
+Composite endpoints: endpoints are assembled from a collection handlers.  
+
+Before/after actions: the middleware handler type wraps the rest of the
+handler chain so that it can both inject items that are used downstream
+and process return values.
+
+Dependency injection: injectors, static injectors, and fallible injectors
+can all be used to provide data and code to downstream handlers.  Downstream
+handlers request what they need by including appropriate types in their
+argument lists.  Injectors are invoked only if their outputs are consumed.
+
+Code juxtiposition: when using pre-registered services, endpoint binding can
+be registered next to the code that implements the endpoint even if the endpoints
+are implemented in multiple files and/or packages.
+
+Delayed initialization: initializers for pre-registered services are only executed
+when the service is started and bound to an http server.  This allow code to define
+such endpoints to depend on resources that may not be present unless the service
+is started.
+
+Reduced refactoring cost: handlers and endpoints declare their inputs and outputs
+in the argument lists and return lists.  Handlers only need to know about their own
+inputs and outputs.  The endpoint framework carries the data to where it is needed.
+It does so with a minimum of copies and without recursive searches (see context.Context).
+Type checking is done at service start time (or endpoint binding time when binding to
+services that are already running).
+
+Lower overhead indirect passing: when using context.Context to pass values indirectly,
+the Go type system cannot be used to verify types at compile time or startup time.  Endpoint
+verifies types at startup time allowing code that receives indirectly-passed data simpler.
+As much as possible, work is done at initialization time rather than endpoint invocation time.
+
+Basics
 
 To use the endpoint package, create services first.  After that the
 endpoints can be registered to the service and the service can be started.
+
+Terminology
+
+Service is a collection of endpoints that can be started together and may share
+a handler collection.
+
+Handler is a function that is used to help define an endpoint. 
+
+Handler collection is a group of handlers.
+
+Downstream handlers are handler that are to the right of the current hanlder
+in the list of handlers.  They will be invoked after the current handler.
+
+Upstream handlers are handlers that are to the left of the current handler
+in the list of handlers.  They will have already been invoked by the time the
+current handler is invoked.
 
 Services
 

--- a/endpoint.go
+++ b/endpoint.go
@@ -1,15 +1,3 @@
-// Package endpoint provides wrappers to allow http endpoints to register themselves.
-//
-// Endpoints are generally tied to services.
-//
-// Services can be pre-registered and started later or they can be registered
-// and stated immediately.  Services can be started with a binder that matches
-// http.HandlerFunc, or they can be started with a *mux.Router.  Combined with
-// the pre-register vs. start immedidately, services come in four flavors:
-// ServiceRegistration, Service, ServiceRegistrationWithMux, and ServiceWithMux.
-//
-// Here's an example:
-
 package endpoint
 
 // TODO: tests for CallsInner annotation
@@ -80,8 +68,8 @@ func (r *EndpointRegistration) Start(path string, binder EndpointBinder, preInje
 	binder(path, r.finalFunc)
 }
 
-// Start and endpoint: invokes the endpoint and binds it to the
-// path.   If called more than once, subsequent calls to
+// Start an endpoint: invokes the endpoint and binds it to the  path.   
+// If called more than once, subsequent calls to
 // EndpointRegistrationWithMux methods that act on the route will
 // only act on the last route bound.
 func (r *EndpointRegistrationWithMux) Start(
@@ -102,7 +90,7 @@ func (r *EndpointRegistrationWithMux) Start(
 	return r.route
 }
 
-// Create a http.HandlerFunc from a list of handlers.  This bypasses Service,
+// CreateEndpoint generates a http.HandlerFunc from a list of handlers.  This bypasses Service,
 // ServiceRegistration, ServiceWithMux, and ServiceRegistrationWithMux.  The
 // static initializers are invoked immedately.
 func CreateEndpoint(funcs ...interface{}) func(http.ResponseWriter, *http.Request) {
@@ -116,7 +104,7 @@ func CreateEndpoint(funcs ...interface{}) func(http.ResponseWriter, *http.Reques
 	return reg.finalFunc
 }
 
-// Pre-register an endpoint.  The provided funcs must all match one of the
+// RegisterEndpoint pre-registers an endpoint.  The provided funcs must all match one of the
 // following function signatures: HandlerStaticInjectorType, HandlerInjectorType, HandlerMiddlewareType,
 // WrapperType and HandlerEndpointType.  The functions provided are invoked in-order.
 // Static injectors first and the endpoint last.
@@ -140,7 +128,7 @@ func (s *ServiceRegistration) RegisterEndpoint(path string, funcs ...interface{}
 	return r
 }
 
-// Register and immedately start an endpoint
+// RegisterEndpoint registers and immedately starts an endpoint.
 // The provided funcs must all match one of the
 // following function signatures: HandlerStaticInjectorType, HandlerInjectorType, HandlerMiddlewareType,
 // WrapperType and HandlerEndpointType.  The functions provided are invoked in-order.
@@ -160,7 +148,7 @@ func (s *Service) RegisterEndpoint(path string, funcs ...interface{}) *EndpointR
 	return r
 }
 
-// Pre-register an endpoint.  The provided funcs must all match one of the
+// RegisterEndpoint pre-registers an endpoint.  The provided funcs must all match one of the
 // following function signatures: HandlerStaticInjectorType, HandlerInjectorType, HandlerMiddlewareType,
 // WrapperType and HandlerEndpointType.  The functions provided are invoked in-order.
 // Static injectors first and the endpoint last.
@@ -186,7 +174,7 @@ func (s *ServiceRegistrationWithMux) RegisterEndpoint(path string, funcs ...inte
 	return wmux
 }
 
-// Register and immediately start an endpoint.
+// RegisterEndpoint registers and immediately starts an endpoint.
 // The provided funcs must all match one of the
 // following function signatures: HandlerStaticInjectorType, HandlerInjectorType, HandlerMiddlewareType,
 // WrapperType and HandlerEndpointType.  The functions provided are invoked in-order.

--- a/endpoint.go
+++ b/endpoint.go
@@ -59,7 +59,7 @@ type wrapperCollection struct {
 
 // Start and endpoint: invokes the endpoint and binds it to the
 // path.
-func (r *EndpointRegistration) Start(path string, binder EndpointBinder, preInject map[typeCode]interface{}) {
+func (r *EndpointRegistration) start(path string, binder EndpointBinder, preInject map[typeCode]interface{}) {
 	r.path = path
 	if !r.bound {
 		r.initialize(preInject)
@@ -72,7 +72,7 @@ func (r *EndpointRegistration) Start(path string, binder EndpointBinder, preInje
 // If called more than once, subsequent calls to
 // EndpointRegistrationWithMux methods that act on the route will
 // only act on the last route bound.
-func (r *EndpointRegistrationWithMux) Start(
+func (r *EndpointRegistrationWithMux) start(
 	path string,
 	binder endpointBinderWithMux,
 	preInject map[typeCode]interface{},
@@ -123,7 +123,7 @@ func (s *ServiceRegistration) RegisterEndpoint(path string, funcs ...interface{}
 	r := buildRegistrationPass1(s.collection, path, funcs...)
 	s.endpoints[path] = r
 	if s.started != nil {
-		r.Start(path, s.started.binder, s.collection.injections)
+		r.start(path, s.started.binder, s.collection.injections)
 	}
 	return r
 }
@@ -144,7 +144,7 @@ func (s *Service) RegisterEndpoint(path string, funcs ...interface{}) *EndpointR
 	}
 	r := buildRegistrationPass1(s.collection, path, funcs...)
 	s.endpoints[path] = r
-	r.Start(path, s.binder, s.collection.injections)
+	r.start(path, s.binder, s.collection.injections)
 	return r
 }
 
@@ -169,7 +169,7 @@ func (s *ServiceRegistrationWithMux) RegisterEndpoint(path string, funcs ...inte
 	}
 	s.endpoints[path] = append(s.endpoints[path], wmux)
 	if s.started != nil {
-		wmux.Start(path, s.started.binder, s.collection.injections)
+		wmux.start(path, s.started.binder, s.collection.injections)
 	}
 	return wmux
 }
@@ -188,7 +188,7 @@ func (s *ServiceWithMux) RegisterEndpoint(path string, funcs ...interface{}) *mu
 		muxroutes:            make([]func(*mux.Route) *mux.Route, 0),
 	}
 	s.endpoints[path] = append(s.endpoints[path], wmux)
-	return wmux.Start(path, s.binder, s.collection.injections)
+	return wmux.start(path, s.binder, s.collection.injections)
 }
 
 func buildRegistrationPass1(sc *HandlerCollection, path string, funcs ...interface{}) *EndpointRegistration {

--- a/gorilla.go
+++ b/gorilla.go
@@ -12,7 +12,7 @@ func (r *EndpointRegistrationWithMux) add(f func(m *mux.Route) *mux.Route) {
 	r.muxroutes = append(r.muxroutes, f)
 }
 
-// Returns the *mux.Route that has been registered to this endpoint, if possible
+// Route returns the *mux.Route that has been registered to this endpoint, if possible.
 func (r *EndpointRegistrationWithMux) Route() (*mux.Route, error) {
 	if !r.bound {
 		return nil, fmt.Errorf("Registration is not complete for %s", r.path)
@@ -23,124 +23,124 @@ func (r *EndpointRegistrationWithMux) Route() (*mux.Route, error) {
 	return r.route, nil
 }
 
-// Applies the mux.Route of the same name to this endpoint when Start() is later called
+// BuildOnly applies the mux.Route method of the same name to this endpoint when the endpoint is initialized.
 func (r *EndpointRegistrationWithMux) BuildOnly() *EndpointRegistrationWithMux {
 	r.add(func(m *mux.Route) *mux.Route { return m.BuildOnly() })
 	return r
 }
 
-// Applies the mux.Route of the same name to this endpoint when Start() is later called
+// Applies the mux.Route method of the same name to this endpoint when the endpoint is initialized.
 func (r *EndpointRegistrationWithMux) BuildVarsFunc(f mux.BuildVarsFunc) *EndpointRegistrationWithMux {
 	r.add(func(m *mux.Route) *mux.Route { return m.BuildVarsFunc(f) })
 	return r
 }
 
-// Applies the mux.Route of the same name to this endpoint when Start() is later called
+// Applies the mux.Route method of the same name to this endpoint when the endpoint is initialized.
 func (r *EndpointRegistrationWithMux) Headers(pairs ...string) *EndpointRegistrationWithMux {
 	r.add(func(m *mux.Route) *mux.Route { return m.Headers(pairs...) })
 	return r
 }
 
-// Applies the mux.Route of the same name to this endpoint when Start() is later called
+// Applies the mux.Route method of the same name to this endpoint when the endpoint is initialized.
 func (r *EndpointRegistrationWithMux) HeadersRegexp(pairs ...string) *EndpointRegistrationWithMux {
 	r.add(func(m *mux.Route) *mux.Route { return m.HeadersRegexp(pairs...) })
 	return r
 }
 
-// Applies the mux.Route of the same name to this endpoint when Start() is later called
+// Applies the mux.Route method of the same name to this endpoint when the endpoint is initialized.
 func (r *EndpointRegistrationWithMux) Host(tpl string) *EndpointRegistrationWithMux {
 	r.add(func(m *mux.Route) *mux.Route { return m.Host(tpl) })
 	return r
 }
 
-// Applies the mux.Route of the same name to this endpoint when Start() is later called
+// Applies the mux.Route method of the same name to this endpoint when the endpoint is initialized.
 func (r *EndpointRegistrationWithMux) MatcherFunc(f mux.MatcherFunc) *EndpointRegistrationWithMux {
 	r.add(func(m *mux.Route) *mux.Route { return m.MatcherFunc(f) })
 	return r
 }
 
-// Applies the mux.Route of the same name to this endpoint when Start() is later called
+// Applies the mux.Route method of the same name to this endpoint when the endpoint is initialized.
 func (r *EndpointRegistrationWithMux) Methods(methods ...string) *EndpointRegistrationWithMux {
 	r.add(func(m *mux.Route) *mux.Route { return m.Methods(methods...) })
 	return r
 }
 
-// Applies the mux.Route of the same name to this endpoint when Start() is later called
+// Applies the mux.Route method of the same name to this endpoint when the endpoint is initialized.
 func (r *EndpointRegistrationWithMux) Name(name string) *EndpointRegistrationWithMux {
 	r.add(func(m *mux.Route) *mux.Route { return m.Name(name) })
 	return r
 }
 
-// Applies the mux.Route of the same name to this endpoint when Start() is later called
+// Applies the mux.Route method of the same name to this endpoint when the endpoint is initialized.
 func (r *EndpointRegistrationWithMux) Path(tpl string) *EndpointRegistrationWithMux {
 	r.add(func(m *mux.Route) *mux.Route { return m.Path(tpl) })
 	return r
 }
 
-// Applies the mux.Route of the same name to this endpoint when Start() is later called
+// Applies the mux.Route method of the same name to this endpoint when the endpoint is initialized.
 func (r *EndpointRegistrationWithMux) PathPrefix(tpl string) *EndpointRegistrationWithMux {
 	r.add(func(m *mux.Route) *mux.Route { return m.PathPrefix(tpl) })
 	return r
 }
 
-// Applies the mux.Route of the same name to this endpoint when Start() is later called
+// Applies the mux.Route method of the same name to this endpoint when the endpoint is initialized.
 func (r *EndpointRegistrationWithMux) Queries(pairs ...string) *EndpointRegistrationWithMux {
 	r.add(func(m *mux.Route) *mux.Route { return m.Queries(pairs...) })
 	return r
 }
 
-// Applies the mux.Route of the same name to this endpoint when Start() is later called
+// Applies the mux.Route method of the same name to this endpoint when the endpoint is initialized.
 func (r *EndpointRegistrationWithMux) Schemes(schemes ...string) *EndpointRegistrationWithMux {
 	r.add(func(m *mux.Route) *mux.Route { return m.Schemes(schemes...) })
 	return r
 }
 
-// Calls the mux.Route method of the same name on the route created for this endpoint when Start() was called
+// Calls the mux.Route method of the same name on the route created for this endpoint.
 func (r *EndpointRegistrationWithMux) GetError() error {
 	return r.err
 }
 
-// Calls the mux.Route method of the same name on the route created for this endpoint when Start() was called
+// Calls the mux.Route method of the same name on the route created for this endpoint.
 func (r *EndpointRegistrationWithMux) GetHandler() http.Handler {
 	return r.route.GetHandler()
 }
 
-// Calls the mux.Route method of the same name on the route created for this endpoint when Start() was called
+// Calls the mux.Route method of the same name on the route created for this endpoint.
 func (r *EndpointRegistrationWithMux) GetHostTemplate() (string, error) {
 	return r.route.GetHostTemplate()
 }
 
-// Calls the mux.Route method of the same name on the route created for this endpoint when Start() was called
+// Calls the mux.Route method of the same name on the route created for this endpoint.
 func (r *EndpointRegistrationWithMux) GetName() string {
 	return r.route.GetName()
 }
 
-// Calls the mux.Route method of the same name on the route created for this endpoint when Start() was called
+// Calls the mux.Route method of the same name on the route created for this endpoint.
 func (r *EndpointRegistrationWithMux) GetPathTemplate() (string, error) {
 	return r.route.GetPathTemplate()
 }
 
-// Calls the mux.Route method of the same name on the route created for this endpoint when Start() was called
+// Calls the mux.Route method of the same name on the route created for this endpoint.
 func (r *EndpointRegistrationWithMux) Match(req *http.Request, match *mux.RouteMatch) bool {
 	return r.route.Match(req, match)
 }
 
-// Calls the mux.Route method of the same name on the route created for this endpoint when Start() was called
+// Calls the mux.Route method of the same name on the route created for this endpoint.
 func (r *EndpointRegistrationWithMux) SkipClean() bool {
 	return r.route.SkipClean()
 }
 
-// Calls the mux.Route method of the same name on the route created for this endpoint when Start() was called
+// Calls the mux.Route method of the same name on the route created for this endpoint.
 func (r *EndpointRegistrationWithMux) URL(pairs ...string) (*url.URL, error) {
 	return r.route.URL(pairs...)
 }
 
-// Calls the mux.Route method of the same name on the route created for this endpoint when Start() was called
+// Calls the mux.Route method of the same name on the route created for this endpoint.
 func (r *EndpointRegistrationWithMux) URLHost(pairs ...string) (*url.URL, error) {
 	return r.URLHost(pairs...)
 }
 
-// Calls the mux.Route method of the same name on the route created for this endpoint when Start() was called
+// Calls the mux.Route method of the same name on the route created for this endpoint.
 func (r *EndpointRegistrationWithMux) URLPath(pairs ...string) (*url.URL, error) {
 	return r.URLPath(pairs...)
 }

--- a/service.go
+++ b/service.go
@@ -26,6 +26,12 @@ type HandlerCollection struct {
 // Since handlers will be invoked in order, this also implies
 // that nothing that follows this handler is a static injector.
 //
+// For example:
+//
+//	var InjectCurrentTime = AnnotateNotStatic(func() time.Time {
+//		return time.Now()
+//	})
+//
 // EXPERIMENTAL FEATURE. MAY BE REMOVED.
 func AnnotateNotStatic(handlerOrCollection interface{}) interface{} {
 	return annotateNotStatic(handlerOrCollection)
@@ -40,8 +46,20 @@ var annotateNotStatic = makeAnnotate(func(fm *funcOrigin) {
 // an injector that produces at least one type and none of the
 // types that the injector produce are consumed dropped from the
 // dropped from the handler list.  If AnnotateSideEffects() is
-// used to wrap that injector, then the injector will not be
-// droped as useless.
+// used to wrap that injector, then the injector will be invoked
+// even though its output is not used.
+//
+// For example:
+//
+//	var counter = 0
+//	var counterLock sync.Mutex
+//      type InvocationCounter int
+//	var CountEndpointInvocations = AnnotateSideEffects(func() InvocationCounter {
+//		counterLock.Lock()
+//		counter++
+//		counterLock.Unlock()
+//		return InvocationCounter(counter)
+//	})
 //
 // EXPERIMENTAL FEATURE. MAY BE REMOVED.
 func AnnotateSideEffects(handlerOrCollection interface{}) interface{} {
@@ -56,10 +74,9 @@ var annotateSideEffects = makeAnnotate(func(fm *funcOrigin) {
 // marks that HandlerMiddlewareType handler as guaranteed to call
 // inner().  This is important only in the case when a downstream
 // handler is returning a value consumed by an upstream HandlerMiddlewareType
-// handler and that value has no easy zero value that can be
-// injected by the HandlerMiddlewareType handler in the event that inner()
-// is not called.  Without AnnotateCallsInner(), some handler
-// sequences may be rejected.
+// handler and that value has no zero value that reflect can generate
+// in the event that inner() is not called.  
+// Without AnnotateCallsInner(), some handler  sequences may be rejected.
 //
 // EXPERIMENTAL FEATURE. MAY BE REMOVED.
 func AnnotateCallsInner(handlerOrCollection interface{}) interface{} {
@@ -134,11 +151,11 @@ type funcOrigin struct {
 type injectionWish typeCode
 
 // AutoInject makes a promise that values will be provided
-// to the service via Inject() before the service is started.  This is done
+// to the service via service.Inject() before the service is started.  This is done
 // by either providing an example of the type or by providing a reflect.Type.
 // The value provided is not retained, just the type of the value provided.
 //
-// This only applies to pre-registered services.
+// This is only relevant for pre-registered services.
 //
 // EXPERIMENTAL FEATURE. MAY BE REMOVED.
 func AutoInject(v interface{}) injectionWish {
@@ -164,7 +181,7 @@ func NewHandlerCollection(name string, funcs ...interface{}) *HandlerCollection 
 	return newHandlerCollection(name, false, funcs...)
 }
 
-// NewHandlerCollectionWithEndpoint creates a handler collection that includes an endpoint
+// NewHandlerCollectionWithEndpoint creates a handler collection that includes an endpoint.
 func NewHandlerCollectionWithEndpoint(name string, funcs ...interface{}) *HandlerCollection {
 	return newHandlerCollection(name, true, funcs...)
 }
@@ -277,6 +294,8 @@ func (c *HandlerCollection) forEach(fn func(*funcOrigin)) {
 //
 // PreRegsteredServices do not initialize or bind to handlers until
 // they are Start()ed.
+//
+// The name of the service is just used for error messages and is otherwise ignored.
 func PreRegisterService(name string, funcs ...interface{}) *ServiceRegistration {
 	return registerService(name, funcs...)
 }
@@ -298,6 +317,8 @@ func RegisterService(name string, binder EndpointBinder, funcs ...interface{}) *
 //
 // PreRegsteredServices do not initialize or bind to handlers until
 // they are Start()ed.
+//
+// The name of the service is just used for error messages and is otherwise ignored.
 func PreRegisterServiceWithMux(name string, funcs ...interface{}) *ServiceRegistrationWithMux {
 	return registerServiceWithMux(name, funcs...)
 }
@@ -338,14 +359,12 @@ func registerServiceWithMux(name string, funcs ...interface{}) *ServiceRegistrat
 	}
 }
 
-// To start a ServiceRegistration, you must pass a binder to bind
-// the endpoint to a route.
-//
-// This is the simple binder function signature.
+// EndpointBinder is the signature of the binding function
+// used to start a ServiceRegistration.
 type EndpointBinder func(path string, fn http.HandlerFunc)
 
-// Run all staticInjectors for all endpoints pre-registered with this
-// service.  Bind all enpoints and start listening.   Start() may
+// Start runs all staticInjectors for all endpoints pre-registered with this
+// service.  Bind all endpoints and starts listening.   Start() may
 // only be called once.
 func (s *ServiceRegistration) Start(binder EndpointBinder) *Service {
 	s.lock.Lock()
@@ -366,7 +385,7 @@ func (s *ServiceRegistration) Start(binder EndpointBinder) *Service {
 	return svc
 }
 
-// Provide a value for one of the types promised by AutoInject
+// Inject provides a value for one of the types promised by AutoInject.
 func (s *ServiceRegistration) Inject(v interface{}) *ServiceRegistration {
 	s.lock.Lock()
 	defer s.lock.Unlock()
@@ -376,7 +395,7 @@ func (s *ServiceRegistration) Inject(v interface{}) *ServiceRegistration {
 
 type endpointBinderWithMux func(string, func(http.ResponseWriter, *http.Request)) *mux.Route
 
-// Provide a value for one of the types promised by AutoInject
+// Inject provides a value for one of the types promised by AutoInject.
 func (s *ServiceRegistrationWithMux) Inject(v interface{}) *ServiceRegistrationWithMux {
 	s.collection.injections[GetTypeCode(reflect.TypeOf(v))] = v
 	return s

--- a/service.go
+++ b/service.go
@@ -373,7 +373,7 @@ func (s *ServiceRegistration) Start(binder EndpointBinder) *Service {
 		panic("duplicate call to Start()")
 	}
 	for path, endpoint := range s.endpoints {
-		endpoint.Start(path, binder, s.collection.injections)
+		endpoint.start(path, binder, s.collection.injections)
 	}
 	svc := &Service{
 		Name:       s.Name,
@@ -411,7 +411,7 @@ func (s *ServiceRegistrationWithMux) Start(router *mux.Router) *ServiceWithMux {
 	}
 	for path, el := range s.endpoints {
 		for _, endpoint := range el {
-			endpoint.Start(path, router.HandleFunc, s.collection.injections)
+			endpoint.start(path, router.HandleFunc, s.collection.injections)
 		}
 	}
 	svc := &ServiceWithMux{


### PR DESCRIPTION
I had time to rewrite much of the documentation during my flight.

Also: got rid of endpoint.Start().   I don't know why it was exported in the first place.

@charlieschwabacher - please review